### PR TITLE
python-extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ build
 
 # Hidden files
 .DS_Store
+
+# Python
+py-ext/build/
+py-ext/dist/
+*.pyc
+*.pyo
+*.egg-info

--- a/python-ext/README.md
+++ b/python-ext/README.md
@@ -1,0 +1,14 @@
+### Install
+
+QuickBlocks must be built with -fPIC 
+Change the src/CMakeLists.txt
+starting line 46:
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -O2 -fPIC")
+if(APPLE)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wconversion -Wall -O2 -fPIC")
+endif()
+
+
+To install, just run:
+python setup.py install

--- a/python-ext/bin/print_blocks.py
+++ b/python-ext/bin/print_blocks.py
@@ -1,0 +1,7 @@
+from quickblocks import QuickBlocks
+
+qb = QuickBlocks('http://localhost:8545', cache=True)
+for i in range(5200000):
+    block = qb[i]
+    if i % 1000 == 0:
+        print(block)

--- a/python-ext/bin/print_blocks.py
+++ b/python-ext/bin/print_blocks.py
@@ -1,3 +1,15 @@
+"""
+QuickBlocks - Decentralized, useful, and detailed data from Ethereum blockchains
+Copyright (c) 2018 Great Hill Corporation (http://quickblocks.io)
+This program is free software: you may redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version. This program is
+distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details. You should have received a copy of the GNU General
+Public License along with this program. If not, see http://www.gnu.org/licenses/.
+"""
+
 from quickblocks import QuickBlocks
 
 qb = QuickBlocks('http://localhost:8545', cache=True)

--- a/python-ext/extension.cpp
+++ b/python-ext/extension.cpp
@@ -1,0 +1,53 @@
+#include <Python.h>
+#include "etherlib.h"
+
+static PyObject* init(PyObject* self, PyObject *args) {
+    const char *baseURL;
+    PyArg_ParseTuple(args, "s", &baseURL);
+    getCurlContext()->baseURL = baseURL;
+    etherlib_init();
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject* cleanup(PyObject* self, PyObject *args) {
+    etherlib_cleanup();
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+// my use case is not live so assuming all finalized
+static PyObject* get_block(PyObject* self, PyObject *args) {
+    int i;
+    int cache;
+    if (!PyArg_ParseTuple(args, "ip", &i, &cache)) {
+        return NULL;
+    }
+    CBlock block;
+    getBlock(block, i);
+    block.finalized = true;
+    if (cache) {
+	writeBlockToBinary(block, getBinaryFilename(i));
+    }
+    return Py_BuildValue("s", block.Format().c_str());
+}
+
+static PyMethodDef _quickblocks_methods[] = {
+    {"get_block", get_block, METH_VARARGS, "get_block"},
+    {"init", init, METH_VARARGS, "init"},
+    {"cleanup", cleanup, METH_VARARGS, "cleanup"},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef cModPyDem =
+{
+    PyModuleDef_HEAD_INIT,
+    "_quickblocks",
+    "",
+    -1,
+    _quickblocks_methods
+};
+
+PyMODINIT_FUNC PyInit__quickblocks(void) {
+    return PyModule_Create(&cModPyDem);
+}

--- a/python-ext/extension.cpp
+++ b/python-ext/extension.cpp
@@ -1,3 +1,16 @@
+/*-------------------------------------------------------------------------------------------
+ * QuickBlocks - Decentralized, useful, and detailed data from Ethereum blockchains
+ * Copyright (c) 2018 Great Hill Corporation (http://quickblocks.io)
+ *
+ * This program is free software: you may redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version. This program is
+ * distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details. You should have received a copy of the GNU General
+ * Public License along with this program. If not, see http://www.gnu.org/licenses/.
+ *-------------------------------------------------------------------------------------------*/
+
 #include <Python.h>
 #include "etherlib.h"
 

--- a/python-ext/quickblocks/__init__.py
+++ b/python-ext/quickblocks/__init__.py
@@ -1,1 +1,13 @@
+"""
+QuickBlocks - Decentralized, useful, and detailed data from Ethereum blockchains
+Copyright (c) 2018 Great Hill Corporation (http://quickblocks.io)
+This program is free software: you may redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version. This program is
+distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details. You should have received a copy of the GNU General
+Public License along with this program. If not, see http://www.gnu.org/licenses/.
+"""
+
 from quickblocks.qb import QuickBlocks

--- a/python-ext/quickblocks/__init__.py
+++ b/python-ext/quickblocks/__init__.py
@@ -1,0 +1,1 @@
+from quickblocks.qb import QuickBlocks

--- a/python-ext/quickblocks/qb.py
+++ b/python-ext/quickblocks/qb.py
@@ -1,0 +1,13 @@
+import _quickblocks as qbe
+import json
+
+class QuickBlocks(object):
+    def __init__(self, url, cache):
+        qbe.init(url)
+        self.cache = True
+
+    def __getitem__(self, blockNum):
+        return json.loads(qbe.get_block(blockNum, self.cache))
+
+    def __del__(self):
+        qbe.cleanup()

--- a/python-ext/quickblocks/qb.py
+++ b/python-ext/quickblocks/qb.py
@@ -1,3 +1,15 @@
+"""
+QuickBlocks - Decentralized, useful, and detailed data from Ethereum blockchains
+Copyright (c) 2018 Great Hill Corporation (http://quickblocks.io)
+This program is free software: you may redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version. This program is
+distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details. You should have received a copy of the GNU General
+Public License along with this program. If not, see http://www.gnu.org/licenses/.
+"""
+
 import _quickblocks as qbe
 import json
 

--- a/python-ext/setup.py
+++ b/python-ext/setup.py
@@ -1,0 +1,18 @@
+from setuptools import find_packages
+from distutils.core import setup, Extension
+
+extension = Extension(name='_quickblocks',
+        include_dirs = ['/usr/local/include', '/usr/include/python3.6','/usr/local/qblocks/include' ],
+        libraries = ['pthread'],
+        sources = ['extension.cpp'],
+        language='c++',
+        extra_compile_args = ['-std=c++11', '-Werror', '-Wall', '-O2', '-fPIC'],
+        extra_link_args = ['-L/usr/local/qblocks/lib', '-lacct', '-lether', '-lutil', '-lcurl'])
+
+setup(name = 'QuickBlocks',
+        version = '0.1.0',
+        description = '',
+        author = 'Mike Zhai',
+        scripts=['bin/print_blocks.py'],
+        packages=find_packages(),
+        ext_modules=[extension])


### PR DESCRIPTION
Adds a python extension for quickBlocks that only implements getting blocks at the time.